### PR TITLE
#39 Upgrade lodash to version 4.17.5 or later

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "intl": "1.2.5",
     "invariant": "2.2.1",
     "ip": "1.1.3",
-    "lodash": "4.16.4",
+    "lodash": ">=4.17.5",
     "material-ui": "^0.16.4",
     "minimist": "1.2.0",
     "react": "15.4.1",


### PR DESCRIPTION
Obs: I've had some issues with installing `ngrok` but from what I can tell, this upgrade doesn't break things.