### PR TITLE
Tempfix date display in Safari (macOS and iOS)

### DIFF
--- a/app/components/ItemIncident/index.js
+++ b/app/components/ItemIncident/index.js
@@ -97,7 +97,7 @@ function IncidentItem(props) {
       font-size: 14px;
     }`;
   const Calendar = ({ createdAt }) => {
-    const createdAtFormatted = new Date(createdAt);
+    const createdAtFormatted = new Date(createdAt.replace(' ', 'T'));
     return (<CalendarWrap>
       <div className="month">
         {createdAtFormatted.toLocaleString('en-us', { month: 'short' })}


### PR DESCRIPTION
Quick fix for the following issue, which seems to happen in Safari on both macOS and iOS:

<img width="509" alt="Screenshot 2019-05-26 at 12 54 14" src="https://user-images.githubusercontent.com/1569300/58380275-c3122600-7fb7-11e9-906d-294b05be0d1e.png">

This updates the date time string format used to the [ECMAScript standard](https://tc39.github.io/ecma262/#sec-date-time-string-format) in the frontend, but it should ideally be updated [in the api](https://github.com/code4romania/monitorizare-vot-votanti-api/blob/develop/app/Api/V1/Transformers/IncidentTransformer.php#L24).
